### PR TITLE
Correct catchall name

### DIFF
--- a/tasks/catchall.yml
+++ b/tasks/catchall.yml
@@ -5,5 +5,5 @@
 - name: Create catchall config
   template:
     src: catchall.conf
-    dest: /etc/nginx/sites-enabled/00_catchall.conf
+    dest: /etc/nginx/sites-enabled/catchall.conf
   notify: nginx restart

--- a/tasks/catchall.yml
+++ b/tasks/catchall.yml
@@ -1,9 +1,9 @@
-- fail: 
+- fail:
     msg: "nginx_catchall_enable needs nginx_delete_default_site to be set!"
   when: not nginx_delete_default_site
 
 - name: Create catchall config
   template:
     src: catchall.conf
-    dest: /etc/nginx/sites-enabled/catchall.conf
+    dest: /etc/nginx/sites-enabled/00_catchall.conf
   notify: nginx restart

--- a/templates/catchall.conf
+++ b/templates/catchall.conf
@@ -1,6 +1,6 @@
 server {
     listen 80;
-    server_name _;
+    server_name _ default_server;
 
     {% if nginx_catchall_answers_acme_challenge %}
     location ^~ /.well-known/acme-challenge/ {


### PR DESCRIPTION
nginx process files in alphabetical order. This is a problem when a site is alphabetically before catchall when https redirecting.
