### PR TITLE
Setup nginx config for website while deployment with ansible

### DIFF
--- a/tasks/packages.yml
+++ b/tasks/packages.yml
@@ -5,4 +5,4 @@
   with_items:
     - nginx
     - ssl-cert # needed for snakeoil certs
-    - python-passlib # needed for some nginx-related ansible actions, such as htpasswd
+    - python3-passlib # needed for some nginx-related ansible actions, such as htpasswd

--- a/tasks/proxy_pass.yml
+++ b/tasks/proxy_pass.yml
@@ -3,12 +3,13 @@
 
 - set_fact:
     conf_filename: "{% if proxy_pass.server_name == '_' %}catchall_simple_proxy_pass{% else %}{{ proxy_pass.server_name }}{% endif %}"
+    site_config_path: "{% if site_config_path == '_' %}simple_proxy_pass.conf{% else %}{{ site_config_path }}{% endif %}"
 - name: Check if SSL config is there
   stat: path="/etc/nginx/snippets/{{ conf_filename }}.ssl.conf"
   register: ssl_config_file
 
 - name: Create nginx sites config
-  template: src=simple_proxy_pass.conf dest=/etc/nginx/sites-enabled/{{ conf_filename }}.conf
+  template: src={{ site_config_path }} dest=/etc/nginx/sites-enabled/{{ conf_filename }}.conf
   notify:
     - nginx restart
 


### PR DESCRIPTION
- Create variable for site conf, to have define site config file path
- Bug-fix: Change python-passlib to python3-passlib, because python-passlib lib doesn't available.